### PR TITLE
Fix tests package import path

### DIFF
--- a/formatter/ascii_test.go
+++ b/formatter/ascii_test.go
@@ -5,7 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/yudai/gojsondiff/test"
+	. "github.com/yudai/gojsondiff/tests"
 
 	diff "github.com/yudai/gojsondiff"
 )

--- a/formatter/delta_test.go
+++ b/formatter/delta_test.go
@@ -5,7 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/yudai/gojsondiff/test"
+	. "github.com/yudai/gojsondiff/tests"
 
 	diff "github.com/yudai/gojsondiff"
 )


### PR DESCRIPTION
Hi, thank you for the great library.

I noticed that I cannot run `go test ./formatter` because import path is wrong, so I fixed it.
Now, you can run `go test ./...` with this pull request.

Please take a look.