### PR TITLE
Show null instead of nil by ascii formatter

### DIFF
--- a/FIXTURES/base.json
+++ b/FIXTURES/base.json
@@ -9,5 +9,6 @@
         "num": 19,
         "arr": [17, "str", {"str": "eafeb"}],
         "obj": {"str": "efj3", "num": 14}
-    }
+    },
+    "null": null
 }

--- a/formatter/ascii.go
+++ b/formatter/ascii.go
@@ -229,6 +229,8 @@ func (f *AsciiFormatter) printValue(value interface{}) {
 	switch value.(type) {
 	case string:
 		f.buffer += fmt.Sprintf(`"%s"`, value)
+	case nil:
+		f.buffer += "null"
 	default:
 		f.buffer += fmt.Sprintf(`%#v`, value)
 	}

--- a/formatter/ascii_test.go
+++ b/formatter/ascii_test.go
@@ -43,6 +43,7 @@ var _ = Describe("Ascii", func() {
      ]
    ],
    "bool": true,
+-  "null": null,
    "num_float": 39.39,
    "num_int": 13,
    "obj": {

--- a/formatter/delta_test.go
+++ b/formatter/delta_test.go
@@ -56,6 +56,7 @@ var _ = Describe("Delta", func() {
 								},
 							},
 						},
+						"null": []interface{}{nil, 0, 0},
 						"obj": map[string]interface{}{
 							"arr": map[string]interface{}{
 								"_t": "a",


### PR DESCRIPTION
@yudai 

Ascii formatter outputs `<nil>` for `null` value, but it should be `null` because it's JSON after all.
I also added tests.

Please  check. Thanks in advance!